### PR TITLE
Add interest level filtering to each column on the job board

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,6 +15,13 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
@@ -26,6 +33,8 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+type InterestFilter = "All" | "High" | "Medium" | "Low";
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,10 +44,18 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+  const statusSlug = status.replace(/\s+/g, "-").toLowerCase();
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${statusSlug}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
@@ -46,10 +63,36 @@ function KanbanColumn({
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${statusSlug}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
+      </div>
+      <div className="px-2 pt-2">
+        <Select
+          value={interestFilter}
+          onValueChange={(val) => setInterestFilter(val as InterestFilter)}
+        >
+          <SelectTrigger
+            className="h-7 text-xs w-full"
+            data-testid={`filter-interest-${statusSlug}`}
+          >
+            <Filter className="w-3 h-3 mr-1 shrink-0" />
+            <SelectValue placeholder="Filter interest" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All" data-testid={`filter-option-all-${statusSlug}`}>All Interest Levels</SelectItem>
+            {INTEREST_LEVELS.map((level) => (
+              <SelectItem
+                key={level}
+                value={level}
+                data-testid={`filter-option-${level.toLowerCase()}-${statusSlug}`}
+              >
+                {level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +101,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+          ) : filteredProspects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${statusSlug}`}>
+              <p className="text-xs text-muted-foreground">
+                {interestFilter === "All" ? "No prospects" : `No ${interestFilter.toLowerCase()} interest prospects`}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -1,4 +1,5 @@
 import { validateProspect } from "../prospect-helpers";
+import { INTEREST_LEVELS } from "@shared/schema";
 
 describe("prospect creation validation", () => {
   test("rejects a blank company name", () => {
@@ -19,5 +20,83 @@ describe("prospect creation validation", () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Role title is required");
+  });
+
+  test("accepts all valid interest levels", () => {
+    for (const level of INTEREST_LEVELS) {
+      const result = validateProspect({
+        companyName: "TestCo",
+        roleTitle: "Engineer",
+        interestLevel: level,
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  test("rejects an invalid interest level", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      interestLevel: "Extreme",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      `Interest level must be one of: ${INTEREST_LEVELS.join(", ")}`
+    );
+  });
+});
+
+describe("interest level filtering logic", () => {
+  const mockProspects = [
+    { id: 1, interestLevel: "High", status: "Bookmarked" },
+    { id: 2, interestLevel: "Medium", status: "Bookmarked" },
+    { id: 3, interestLevel: "Low", status: "Bookmarked" },
+    { id: 4, interestLevel: "High", status: "Bookmarked" },
+  ];
+
+  function filterByInterest(
+    prospects: typeof mockProspects,
+    filter: "All" | "High" | "Medium" | "Low"
+  ) {
+    return filter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === filter);
+  }
+
+  test("filter 'All' returns all prospects", () => {
+    const result = filterByInterest(mockProspects, "All");
+    expect(result).toHaveLength(4);
+  });
+
+  test("filter 'High' returns only high interest prospects", () => {
+    const result = filterByInterest(mockProspects, "High");
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.interestLevel === "High")).toBe(true);
+  });
+
+  test("filter 'Medium' returns only medium interest prospects", () => {
+    const result = filterByInterest(mockProspects, "Medium");
+    expect(result).toHaveLength(1);
+    expect(result[0].interestLevel).toBe("Medium");
+  });
+
+  test("filter 'Low' returns only low interest prospects", () => {
+    const result = filterByInterest(mockProspects, "Low");
+    expect(result).toHaveLength(1);
+    expect(result[0].interestLevel).toBe("Low");
+  });
+
+  test("each column filters independently", () => {
+    const bookmarkedProspects = mockProspects.filter((p) => p.status === "Bookmarked");
+    const appliedProspects = [
+      { id: 5, interestLevel: "Low", status: "Applied" },
+    ];
+
+    const bookmarkedHigh = filterByInterest(bookmarkedProspects, "High");
+    const appliedAll = filterByInterest(appliedProspects, "All");
+
+    expect(bookmarkedHigh).toHaveLength(2);
+    expect(appliedAll).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Implement client-side filtering by interest level (Low, Medium, High) within each Kanban column. Add new select components for filtering and update prospect display logic in `home.tsx`. Add server-side tests in `prospect-validation.test.ts` to validate interest level acceptance and rejection, and introduce new tests for the filtering logic itself.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f56074b8-4adb-4649-ae23-2a657ccdcaa8
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: ca584efd-31ce-424b-a642-446b5a728d06
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/533a25fe-2472-47d8-8c99-9d072bcbe227/f56074b8-4adb-4649-ae23-2a657ccdcaa8/BVpnYAw
Replit-Helium-Checkpoint-Created: true
Closes #2 