### PR TITLE
Add target salary feature to job tracking application

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      targetSalary: "",
       notes: "",
     },
   });
@@ -156,6 +157,29 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  min="0"
+                  step="0.01"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                  data-testid="input-target-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      targetSalary: prospect.targetSalary ?? "",
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,29 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  min="0"
+                  step="0.01"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                  data-testid="input-edit-target-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,15 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.targetSalary && Number(prospect.targetSalary) > 0 && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+              data-testid={`text-salary-${prospect.id}`}
+            >
+              <DollarSign className="w-3 h-3" />
+              {Number(prospect.targetSalary).toLocaleString("en-US")}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -30,10 +30,11 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, target_salary (numeric 12,2), notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low
+- **Target salary**: Optional decimal field; empty strings normalized to null before DB write; validated as digits only with up to 2 decimal places
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -45,6 +45,100 @@ describe("prospect creation validation", () => {
       `Interest level must be one of: ${INTEREST_LEVELS.join(", ")}`
     );
   });
+
+  test("accepts a valid target salary", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "120000",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts a target salary with decimals", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "95000.50",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts an empty target salary (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts a null target salary (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: null,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts undefined target salary (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects target salary with letters", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "abc",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a valid number");
+  });
+
+  test("rejects target salary with symbols", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "$120,000",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a valid number");
+  });
+
+  test("rejects target salary with mixed letters and numbers", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "120k",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a valid number");
+  });
+
+  test("rejects target salary with too many decimal places", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "120000.123",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a valid number");
+  });
+
+  test("rejects negative target salary", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      targetSalary: "-50000",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a valid number");
+  });
 });
 
 describe("interest level filtering logic", () => {

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,13 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.targetSalary !== undefined && data.targetSalary !== null && data.targetSalary !== "") {
+    const salaryStr = String(data.targetSalary);
+    if (!/^\d+(\.\d{1,2})?$/.test(salaryStr)) {
+      errors.push("Target salary must be a valid number");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,6 +40,14 @@ export async function registerRoutes(
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
 
+    if (body.targetSalary !== undefined) {
+      const salary = body.targetSalary === "" ? null : body.targetSalary;
+      if (salary !== null && !/^\d+(\.\d{1,2})?$/.test(String(salary))) {
+        return res.status(400).json({ message: "Target salary must be a valid number" });
+      }
+      updates.targetSalary = salary;
+    }
+
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {
         return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, numeric } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  targetSalary: numeric("target_salary", { precision: 12, scale: 2 }),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -33,6 +34,12 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   roleTitle: z.string().min(1, "Role title is required"),
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
+  targetSalary: z.string().optional().nullable()
+    .transform((val) => (val === "" ? null : val))
+    .refine(
+      (val) => val === null || val === undefined || /^\d+(\.\d{1,2})?$/.test(val),
+      { message: "Target salary must be a valid number" }
+    ),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });


### PR DESCRIPTION
Adds a 'targetSalary' field to the job prospect schema, forms, and card display. Includes frontend input validation, backend schema updates with a numeric type for exactness, and corresponding tests.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f56074b8-4adb-4649-ae23-2a657ccdcaa8
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 84b8995e-2bc0-4973-85ee-74efc702b474
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/533a25fe-2472-47d8-8c99-9d072bcbe227/f56074b8-4adb-4649-ae23-2a657ccdcaa8/wZmuXlZ
Replit-Helium-Checkpoint-Created: true
Closes #4 