### PR TITLE
Add job location and work mode options to prospect tracking

### DIFF
--- a/.replit
+++ b/.replit
@@ -38,3 +38,6 @@ author = "agent"
 task = "shell.exec"
 args = "npm run dev"
 waitForPort = 5000
+
+[agent]
+expertMode = true

--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, WORK_MODES } from "@shared/schema";
 import type { InsertProspect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -37,6 +37,8 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       targetSalary: "",
+      jobLocation: "",
+      workMode: "",
       notes: "",
     },
   });
@@ -180,6 +182,53 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             </FormItem>
           )}
         />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="jobLocation"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>City/State (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="e.g. Austin, TX"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-job-location"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="workMode"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Work Mode (optional)</FormLabel>
+                <Select onValueChange={(v) => field.onChange(v === "none" ? "" : v)} value={field.value || "none"}>
+                  <FormControl>
+                    <SelectTrigger data-testid="select-work-mode">
+                      <SelectValue placeholder="Select mode" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="none" data-testid="option-work-mode-none">None</SelectItem>
+                    {WORK_MODES.map((mode) => (
+                      <SelectItem key={mode} value={mode} data-testid={`option-work-mode-${mode}`}>
+                        {mode}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, WORK_MODES } from "@shared/schema";
 import type { InsertProspect, Prospect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -42,6 +42,8 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       targetSalary: prospect.targetSalary ?? "",
+      jobLocation: prospect.jobLocation ?? "",
+      workMode: prospect.workMode ?? "",
       notes: prospect.notes ?? "",
     },
   });
@@ -184,6 +186,53 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             </FormItem>
           )}
         />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="jobLocation"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>City/State (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="e.g. Austin, TX"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-edit-job-location"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="workMode"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Work Mode (optional)</FormLabel>
+                <Select onValueChange={(v) => field.onChange(v === "none" ? "" : v)} value={field.value || "none"}>
+                  <FormControl>
+                    <SelectTrigger data-testid="select-edit-work-mode">
+                      <SelectValue placeholder="Select mode" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="none" data-testid="option-edit-work-mode-none">None</SelectItem>
+                    {WORK_MODES.map((mode) => (
+                      <SelectItem key={mode} value={mode} data-testid={`option-edit-work-mode-${mode}`}>
+                        {mode}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, MapPin, Building2, Home, Monitor } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -115,6 +115,31 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
             </span>
           )}
         </div>
+
+        {(prospect.jobLocation || prospect.workMode) && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {prospect.jobLocation && (
+              <span
+                className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-400"
+                data-testid={`text-location-${prospect.id}`}
+              >
+                <MapPin className="w-3 h-3" />
+                {prospect.jobLocation}
+              </span>
+            )}
+            {prospect.workMode && (
+              <span
+                className="inline-flex items-center gap-1 text-xs font-medium text-violet-600 dark:text-violet-400"
+                data-testid={`text-work-mode-${prospect.id}`}
+              >
+                {prospect.workMode === "Remote" ? <Monitor className="w-3 h-3" /> :
+                 prospect.workMode === "Hybrid" ? <Building2 className="w-3 h-3" /> :
+                 <Home className="w-3 h-3" />}
+                {prospect.workMode}
+              </span>
+            )}
+          </div>
+        )}
 
         {prospect.jobUrl && (
           <a

--- a/replit.md
+++ b/replit.md
@@ -30,11 +30,14 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, target_salary (numeric 12,2), notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, target_salary (numeric 12,2), job_location, work_mode, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low
+- **Work modes**: Remote, Hybrid, On-site
 - **Target salary**: Optional decimal field; empty strings normalized to null before DB write; validated as digits only with up to 2 decimal places
+- **Job location**: Optional text field (city/state); empty strings normalized to null, trimmed before save
+- **Work mode**: Optional enum-like text field; validated against allowed values (Remote, Hybrid, On-site)
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -1,5 +1,5 @@
 import { validateProspect } from "../prospect-helpers";
-import { INTEREST_LEVELS } from "@shared/schema";
+import { INTEREST_LEVELS, WORK_MODES } from "@shared/schema";
 
 describe("prospect creation validation", () => {
   test("rejects a blank company name", () => {
@@ -138,6 +138,94 @@ describe("prospect creation validation", () => {
     });
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Target salary must be a valid number");
+  });
+});
+
+describe("job location validation", () => {
+  test("accepts a valid job location", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      jobLocation: "Austin, TX",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts an empty job location (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      jobLocation: "",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts a null job location (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      jobLocation: null,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts undefined job location (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("work mode validation", () => {
+  test("accepts all valid work modes", () => {
+    for (const mode of WORK_MODES) {
+      const result = validateProspect({
+        companyName: "TestCo",
+        roleTitle: "Engineer",
+        workMode: mode,
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  test("rejects an invalid work mode", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      workMode: "Flexible",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      `Work mode must be one of: ${WORK_MODES.join(", ")}`
+    );
+  });
+
+  test("accepts an empty work mode (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      workMode: "",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts a null work mode (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+      workMode: null,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts undefined work mode (optional)", () => {
+    const result = validateProspect({
+      companyName: "TestCo",
+      roleTitle: "Engineer",
+    });
+    expect(result.valid).toBe(true);
   });
 });
 

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -1,4 +1,4 @@
-import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS, WORK_MODES } from "@shared/schema";
 
 export function getNextStatus(currentStatus: string): string {
   const terminalStatuses = ["Offer", "Rejected", "Withdrawn"];
@@ -43,6 +43,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     const salaryStr = String(data.targetSalary);
     if (!/^\d+(\.\d{1,2})?$/.test(salaryStr)) {
       errors.push("Target salary must be a valid number");
+    }
+  }
+
+  if (data.workMode !== undefined && data.workMode !== null && data.workMode !== "") {
+    if (!WORK_MODES.includes(data.workMode as (typeof WORK_MODES)[number])) {
+      errors.push(`Work mode must be one of: ${WORK_MODES.join(", ")}`);
     }
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, WORK_MODES } from "@shared/schema";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -46,6 +46,18 @@ export async function registerRoutes(
         return res.status(400).json({ message: "Target salary must be a valid number" });
       }
       updates.targetSalary = salary;
+    }
+
+    if (body.jobLocation !== undefined) {
+      updates.jobLocation = body.jobLocation === "" ? null : (body.jobLocation?.trim() || null);
+    }
+
+    if (body.workMode !== undefined) {
+      const mode = body.workMode === "" ? null : body.workMode;
+      if (mode !== null && !WORK_MODES.includes(mode)) {
+        return res.status(400).json({ message: `Work mode must be one of: ${WORK_MODES.join(", ")}` });
+      }
+      updates.workMode = mode;
     }
 
     if (body.status !== undefined) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -13,6 +13,7 @@ export const STATUSES = [
 ] as const;
 
 export const INTEREST_LEVELS = ["High", "Medium", "Low"] as const;
+export const WORK_MODES = ["Remote", "Hybrid", "On-site"] as const;
 
 export const prospects = pgTable("prospects", {
   id: serial("id").primaryKey(),
@@ -22,6 +23,8 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   targetSalary: numeric("target_salary", { precision: 12, scale: 2 }),
+  jobLocation: text("job_location"),
+  workMode: text("work_mode"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -41,6 +44,14 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
       { message: "Target salary must be a valid number" }
     ),
   jobUrl: z.string().optional().nullable(),
+  jobLocation: z.string().optional().nullable()
+    .transform((val) => (val === "" ? null : val?.trim() || null)),
+  workMode: z.string().optional().nullable()
+    .transform((val) => (val === "" ? null : val))
+    .refine(
+      (val) => val === null || val === undefined || WORK_MODES.includes(val as (typeof WORK_MODES)[number]),
+      { message: `Work mode must be one of: ${WORK_MODES.join(", ")}` }
+    ),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Introduces new fields for job location and work mode to the prospect schema, forms, and card display. Includes validation and testing for these new optional fields.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f56074b8-4adb-4649-ae23-2a657ccdcaa8
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 7087c939-522c-453b-bf27-3fad55f39198
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/533a25fe-2472-47d8-8c99-9d072bcbe227/f56074b8-4adb-4649-ae23-2a657ccdcaa8/1cOwmJJ
Replit-Helium-Checkpoint-Created: true
Closes #6 